### PR TITLE
Fix version constants to protected

### DIFF
--- a/XojoInstruments/XojoInstruments.xojo_code
+++ b/XojoInstruments/XojoInstruments.xojo_code
@@ -30,13 +30,13 @@ Protected Module XojoInstruments
 	#tag EndComputedProperty
 
 
-	#tag Constant, Name = BugVersion, Type = Double, Dynamic = False, Default = \"1", Scope = Public
+	#tag Constant, Name = BugVersion, Type = Double, Dynamic = False, Default = \"1", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = MajorVersion, Type = Double, Dynamic = False, Default = \"0", Scope = Public
+	#tag Constant, Name = MajorVersion, Type = Double, Dynamic = False, Default = \"0", Scope = Protected
 	#tag EndConstant
 
-	#tag Constant, Name = MinorVersion, Type = Double, Dynamic = False, Default = \"2", Scope = Public
+	#tag Constant, Name = MinorVersion, Type = Double, Dynamic = False, Default = \"2", Scope = Protected
 	#tag EndConstant
 
 


### PR DESCRIPTION
Version constants should be protected instead of global to avoid shadowing constants in App.