### PR TITLE
Do not use Open event handler to support DesktopWindow

### DIFF
--- a/XojoInstruments/XojoInstruments.xojo_code
+++ b/XojoInstruments/XojoInstruments.xojo_code
@@ -12,6 +12,12 @@ Protected Module XojoInstruments
 		      
 		      // Create a window.
 		      desktopGUI = New XojoInstrumentsDesktopGUI()
+		      
+		      // Hide objects in the GUI from snapshot.
+		      XojoInstruments.Snapshot.RegisterSystemObject(desktopGUI)
+		      For i As Integer = desktopGUI.ControlCount - 1 DownTo 0
+		        XojoInstruments.Snapshot.RegisterSystemObject(desktopGUI.Control(i))
+		      Next
 		    End If
 		    
 		    desktopGUI.Show()

--- a/XojoInstruments/XojoInstrumentsDesktopGUI.xojo_window
+++ b/XojoInstruments/XojoInstrumentsDesktopGUI.xojo_window
@@ -1136,17 +1136,6 @@ End
 #tag EndWindow
 
 #tag WindowCode
-	#tag Event
-		Sub Open()
-		  // Hide objects in the window from snapshot.
-		  XojoInstruments.Snapshot.RegisterSystemObject(Me)
-		  For i As Integer = Me.ControlCount - 1 DownTo 0
-		    XojoInstruments.Snapshot.RegisterSystemObject(Me.Control(i))
-		  Next
-		End Sub
-	#tag EndEvent
-
-
 	#tag Method, Flags = &h21
 		Private Function DoCapture(createGraph As Boolean) As XojoInstruments.Snapshot
 		  Dim snap As New XojoInstruments.Snapshot(createGraph)


### PR DESCRIPTION
To make migration from Window (Open) to DesktopWindow (Opening) easy, avoid using events in windows.